### PR TITLE
Changed 3 line to allow for manual input of the scaling factor

### DIFF
--- a/src/Metzli/Renderer/PngRenderer.php
+++ b/src/Metzli/Renderer/PngRenderer.php
@@ -47,9 +47,9 @@ class PngRenderer implements RendererInterface
         return imagecolorallocate($im, $r, $g ,$b);
     }
 
-    public function render(AztecCode $code)
+    public function render(AztecCode $code, $f = false)
     {
-        $f = $this->factor;
+        if(!$f) $f = $this->factor;
         $matrix = $code->getMatrix();
         $im = imagecreatetruecolor($matrix->getWidth() * $f, $matrix->getHeight() * $f);
         $fg = $this->allocateColor($im, $this->fgColor);

--- a/src/Metzli/Renderer/RendererInterface.php
+++ b/src/Metzli/Renderer/RendererInterface.php
@@ -22,5 +22,5 @@ use Metzli\Encoder\AztecCode;
 
 interface RendererInterface
 {
-    public function render(AztecCode $code);
+    public function render(AztecCode $code, $f);
 }


### PR DESCRIPTION
I changed a few lines in RendererInterface and PNGRenderer, so it's now possible to override the default scale factor of 4, if desired, by stating it as a second parameter. That is all.

`$renderer->render($code, 15);`